### PR TITLE
VFB 66 - onSwapRows amended to directly update the row order

### DIFF
--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -38,7 +38,7 @@ interface QuantityAndNotes {
 
 interface ListDataViewProps {
     listOfIngridients: Schema["lists"][];
-    setData: React.Dispatch<React.SetStateAction<Schema["lists"][]>>;
+    setListOfIngridients: React.Dispatch<React.SetStateAction<Schema["lists"][]>>;
     comment: string;
 }
 
@@ -82,8 +82,8 @@ const listsColumnStyleOptions: ColumnStyles<ListRow> = {
 };
 
 const ListsDataView: React.FC<ListDataViewProps> = ({
-    listOfIngridients: setListOfIngridients,
-    setData,
+    listOfIngridients,
+    setListOfIngridients: setData,
     comment,
 }) => {
     const [modal, setModal] = useState<EditModalState>();
@@ -92,11 +92,11 @@ const ListsDataView: React.FC<ListDataViewProps> = ({
     const [toDeleteModalOpen, setToDeleteModalOpen] = useState<boolean>(false);
     const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-    if (setListOfIngridients === null) {
+    if (listOfIngridients === null) {
         throw new Error("No data found");
     }
 
-    const rows = setListOfIngridients.map((row) => {
+    const rows = listOfIngridients.map((row) => {
         const newRow = {
             primaryKey: row.primary_key,
             rowOrder: row.row_order,
@@ -119,27 +119,27 @@ const ListsDataView: React.FC<ListDataViewProps> = ({
     const toggleableHeaders = headerKeysAndLabels.map(([key]) => key);
 
     const onEdit = (index: number): void => {
-        setModal(setListOfIngridients[index]);
+        setModal(listOfIngridients[index]);
     };
 
     const reorderRows = (row1: ListRow, row2: ListRow): void => {
-        const primaryKeys = setListOfIngridients.map(
+        const primaryKeys = listOfIngridients.map(
             (listOfIngridients) => listOfIngridients.primary_key
         );
 
         const row1Index = primaryKeys.indexOf(row1.primaryKey);
         const row2Index = primaryKeys.indexOf(row2.primaryKey);
 
-        const row1Item = setListOfIngridients[row1Index];
+        const row1Item = listOfIngridients[row1Index];
         const row1Order = row1Item.row_order;
 
-        const row2Item = setListOfIngridients[row2Index];
+        const row2Item = listOfIngridients[row2Index];
         const row2Order = row2Item.row_order;
 
         row1Item.row_order = row2Order;
         row2Item.row_order = row1Order;
 
-        const newRowOrder = [...setListOfIngridients];
+        const newRowOrder = [...listOfIngridients];
 
         newRowOrder[row1Index] = row2Item;
         newRowOrder[row2Index] = row1Item;
@@ -172,7 +172,7 @@ const ListsDataView: React.FC<ListDataViewProps> = ({
 
     const onConfirmDeletion = async (): Promise<void> => {
         if (toDelete !== null) {
-            const itemToDelete = setListOfIngridients[toDelete];
+            const itemToDelete = listOfIngridients[toDelete];
             const { error } = await supabase
                 .from("lists")
                 .delete()
@@ -190,7 +190,7 @@ const ListsDataView: React.FC<ListDataViewProps> = ({
         <>
             <ConfirmDialog
                 message={`Are you sure you want to delete ${
-                    toDelete ? setListOfIngridients[toDelete].item_name : ""
+                    toDelete ? listOfIngridients[toDelete].item_name : ""
                 }?`}
                 isOpen={toDeleteModalOpen}
                 onConfirm={onConfirmDeletion}

--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -81,7 +81,11 @@ const listsColumnStyleOptions: ColumnStyles<ListRow> = {
     ),
 };
 
-const ListsDataView: React.FC<ListDataViewProps> = ({ listOfIngridients: setListOfIngridients, setData, comment }) => {
+const ListsDataView: React.FC<ListDataViewProps> = ({
+    listOfIngridients: setListOfIngridients,
+    setData,
+    comment,
+}) => {
     const [modal, setModal] = useState<EditModalState>();
     const [toDelete, setToDelete] = useState<number | null>(null);
     // need another setState otherwise the modal content changes before the close animation finishes

--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -118,6 +118,30 @@ const ListsDataView: React.FC<ListDataViewProps> = ({ listOfIngridients, setData
         setModal(listOfIngridients[index]);
     };
 
+    const reorderRows = (row1: ListRow, row2: ListRow): void => {
+        const primaryKeys = listOfIngridients.map(
+            (listOfIngridients) => listOfIngridients.primary_key
+        );
+
+        const row1Index = primaryKeys.indexOf(row1.primaryKey);
+        const row2Index = primaryKeys.indexOf(row2.primaryKey);
+
+        const row1Item = listOfIngridients[row1Index];
+        const row1Order = row1Item.row_order;
+
+        const row2Item = listOfIngridients[row2Index];
+        const row2Order = row2Item.row_order;
+
+        row1Item.row_order = row2Order;
+        row2Item.row_order = row1Order;
+
+        const newRowOrder = [...listOfIngridients];
+
+        newRowOrder[row1Index] = row2Item;
+        newRowOrder[row2Index] = row1Item;
+
+        setData(newRowOrder);
+    };
     const onSwapRows = async (row1: ListRow, row2: ListRow): Promise<void> => {
         const { error } = await supabase.from("lists").upsert([
             {
@@ -134,28 +158,7 @@ const ListsDataView: React.FC<ListDataViewProps> = ({ listOfIngridients, setData
             throw new DatabaseError("update", "lists items");
         }
 
-        const primaryKeys = listOfIngridients.map(
-            (listOfIngridients) => listOfIngridients.primary_key
-        );
-
-        const index1 = primaryKeys.indexOf(row1.primaryKey);
-        const index2 = primaryKeys.indexOf(row2.primaryKey);
-
-        const item1 = listOfIngridients[index1];
-        const order1 = item1.row_order;
-
-        const item2 = listOfIngridients[index2];
-        const order2 = item2.row_order;
-
-        item1.row_order = order2;
-        item2.row_order = order1;
-
-        const newData = [...listOfIngridients];
-
-        newData[index1] = item2;
-        newData[index2] = item1;
-
-        setData(newData);
+        reorderRows(row1, row2);
     };
 
     const onDeleteButtonClick = (index: number): void => {

--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -81,18 +81,18 @@ const listsColumnStyleOptions: ColumnStyles<ListRow> = {
     ),
 };
 
-const ListsDataView: React.FC<ListDataViewProps> = ({ listOfIngridients, setData, comment }) => {
+const ListsDataView: React.FC<ListDataViewProps> = ({ listOfIngridients: setListOfIngridients, setData, comment }) => {
     const [modal, setModal] = useState<EditModalState>();
     const [toDelete, setToDelete] = useState<number | null>(null);
     // need another setState otherwise the modal content changes before the close animation finishes
     const [toDeleteModalOpen, setToDeleteModalOpen] = useState<boolean>(false);
     const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-    if (listOfIngridients === null) {
+    if (setListOfIngridients === null) {
         throw new Error("No data found");
     }
 
-    const rows = listOfIngridients.map((row) => {
+    const rows = setListOfIngridients.map((row) => {
         const newRow = {
             primaryKey: row.primary_key,
             rowOrder: row.row_order,
@@ -115,27 +115,27 @@ const ListsDataView: React.FC<ListDataViewProps> = ({ listOfIngridients, setData
     const toggleableHeaders = headerKeysAndLabels.map(([key]) => key);
 
     const onEdit = (index: number): void => {
-        setModal(listOfIngridients[index]);
+        setModal(setListOfIngridients[index]);
     };
 
     const reorderRows = (row1: ListRow, row2: ListRow): void => {
-        const primaryKeys = listOfIngridients.map(
+        const primaryKeys = setListOfIngridients.map(
             (listOfIngridients) => listOfIngridients.primary_key
         );
 
         const row1Index = primaryKeys.indexOf(row1.primaryKey);
         const row2Index = primaryKeys.indexOf(row2.primaryKey);
 
-        const row1Item = listOfIngridients[row1Index];
+        const row1Item = setListOfIngridients[row1Index];
         const row1Order = row1Item.row_order;
 
-        const row2Item = listOfIngridients[row2Index];
+        const row2Item = setListOfIngridients[row2Index];
         const row2Order = row2Item.row_order;
 
         row1Item.row_order = row2Order;
         row2Item.row_order = row1Order;
 
-        const newRowOrder = [...listOfIngridients];
+        const newRowOrder = [...setListOfIngridients];
 
         newRowOrder[row1Index] = row2Item;
         newRowOrder[row2Index] = row1Item;
@@ -168,7 +168,7 @@ const ListsDataView: React.FC<ListDataViewProps> = ({ listOfIngridients, setData
 
     const onConfirmDeletion = async (): Promise<void> => {
         if (toDelete !== null) {
-            const itemToDelete = listOfIngridients[toDelete];
+            const itemToDelete = setListOfIngridients[toDelete];
             const { error } = await supabase
                 .from("lists")
                 .delete()
@@ -186,7 +186,7 @@ const ListsDataView: React.FC<ListDataViewProps> = ({ listOfIngridients, setData
         <>
             <ConfirmDialog
                 message={`Are you sure you want to delete ${
-                    toDelete ? listOfIngridients[toDelete].item_name : ""
+                    toDelete ? setListOfIngridients[toDelete].item_name : ""
                 }?`}
                 isOpen={toDeleteModalOpen}
                 onConfirm={onConfirmDeletion}

--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -83,7 +83,7 @@ const listsColumnStyleOptions: ColumnStyles<ListRow> = {
 
 const ListsDataView: React.FC<ListDataViewProps> = ({
     listOfIngridients,
-    setListOfIngridients: setData,
+    setListOfIngridients: setListOfIngridients,
     comment,
 }) => {
     const [modal, setModal] = useState<EditModalState>();
@@ -139,12 +139,12 @@ const ListsDataView: React.FC<ListDataViewProps> = ({
         row1Item.row_order = row2Order;
         row2Item.row_order = row1Order;
 
-        const newRowOrder = [...listOfIngridients];
+        const newListOfIngridients = [...listOfIngridients];
 
-        newRowOrder[row1Index] = row2Item;
-        newRowOrder[row2Index] = row1Item;
+        newListOfIngridients[row1Index] = row2Item;
+        newListOfIngridients[row2Index] = row1Item;
 
-        setData(newRowOrder);
+        setListOfIngridients(newListOfIngridients);
     };
     const onSwapRows = async (row1: ListRow, row2: ListRow): Promise<void> => {
         const { error } = await supabase.from("lists").upsert([

--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -134,27 +134,28 @@ const ListsDataView: React.FC<ListDataViewProps> = ({ listOfIngridients, setData
             throw new DatabaseError("update", "lists items");
         }
 
+        const primaryKeys = listOfIngridients.map(
+            (listOfIngridients) => listOfIngridients.primary_key
+        );
 
-        const primaryKeys = listOfIngridients.map(listOfIngridients => listOfIngridients.primary_key)
+        const index1 = primaryKeys.indexOf(row1.primaryKey);
+        const index2 = primaryKeys.indexOf(row2.primaryKey);
 
-        const index1 = primaryKeys.indexOf(row1.primaryKey)
-        const index2 = primaryKeys.indexOf(row2.primaryKey)
+        const item1 = listOfIngridients[index1];
+        const order1 = item1.row_order;
 
-        const item1 = listOfIngridients[index1]
-        const order1 = item1.row_order
+        const item2 = listOfIngridients[index2];
+        const order2 = item2.row_order;
 
-        const item2 = listOfIngridients[index2]
-        const order2 = item2.row_order
+        item1.row_order = order2;
+        item2.row_order = order1;
 
-        item1.row_order = order2
-        item2.row_order = order1
+        const newData = [...listOfIngridients];
 
-        const newData = [...listOfIngridients]
+        newData[index1] = item2;
+        newData[index2] = item1;
 
-        newData[index1] = item2
-        newData[index2] = item1
-
-        setData(newData)
+        setData(newData);
     };
 
     const onDeleteButtonClick = (index: number): void => {

--- a/src/app/lists/ListsPage.tsx
+++ b/src/app/lists/ListsPage.tsx
@@ -31,7 +31,11 @@ const ListsPage: React.FC<{}> = () => {
         })();
     }, []);
 
-    return isLoading ? <></> : <ListsDataView listOfIngridients={listsData} setData={setListsData} comment={comment} />;
+    return isLoading ? (
+        <></>
+    ) : (
+        <ListsDataView listOfIngridients={listsData} setData={setListsData} comment={comment} />
+    );
 };
 
 export default ListsPage;

--- a/src/app/lists/ListsPage.tsx
+++ b/src/app/lists/ListsPage.tsx
@@ -34,7 +34,11 @@ const ListsPage: React.FC<{}> = () => {
     return isLoading ? (
         <></>
     ) : (
-        <ListsDataView listOfIngridients={listsData} setListOfIngridients={setListsData} comment={comment} />
+        <ListsDataView
+            listOfIngridients={listsData}
+            setListOfIngridients={setListsData}
+            comment={comment}
+        />
     );
 };
 

--- a/src/app/lists/ListsPage.tsx
+++ b/src/app/lists/ListsPage.tsx
@@ -31,7 +31,7 @@ const ListsPage: React.FC<{}> = () => {
         })();
     }, []);
 
-    return isLoading ? <></> : <ListsDataView data={listsData} comment={comment} />;
+    return isLoading ? <></> : <ListsDataView listOfIngridients={listsData} setData={setListsData} comment={comment} />;
 };
 
 export default ListsPage;

--- a/src/app/lists/ListsPage.tsx
+++ b/src/app/lists/ListsPage.tsx
@@ -34,7 +34,7 @@ const ListsPage: React.FC<{}> = () => {
     return isLoading ? (
         <></>
     ) : (
-        <ListsDataView listOfIngridients={listsData} setData={setListsData} comment={comment} />
+        <ListsDataView listOfIngridients={listsData} setListOfIngridients={setListsData} comment={comment} />
     );
 };
 

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -97,7 +97,6 @@ const CalendarStyling = styled(Paper)`
     .fc-timeGridWeek-view .fc-event-title-container {
         width: 100%;
         height: 100%;
-        scrollto
     }
 
     .fc-timeGridWeek-view .fc-event-title,

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -97,6 +97,7 @@ const CalendarStyling = styled(Paper)`
     .fc-timeGridWeek-view .fc-event-title-container {
         width: 100%;
         height: 100%;
+        scrollto
     }
 
     .fc-timeGridWeek-view .fc-event-title,


### PR DESCRIPTION
## What's changed
The login of onSwapRows has been updated to use the listOfIngridients function as props to update the row_order value of listsData

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA 
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request
- [x] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request
